### PR TITLE
Dispose only Enumerator when Foreach statement is use.

### DIFF
--- a/Catfood.Shapefile/Catfood.Shapefile.csproj
+++ b/Catfood.Shapefile/Catfood.Shapefile.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Shape.cs" />
     <Compile Include="ShapeFactory.cs" />
     <Compile Include="Shapefile.cs" />
+    <Compile Include="ShapeFileEnumerator.cs" />
     <Compile Include="ShapeMultiPoint.cs" />
     <Compile Include="ShapePoint.cs" />
     <Compile Include="ShapePolygon.cs" />

--- a/Catfood.Shapefile/ShapeFileEnumerator.cs
+++ b/Catfood.Shapefile/ShapeFileEnumerator.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Data.OleDb;
+using System.IO;
+using System.Text;
+
+namespace Catfood.Shapefile
+{
+    class ShapeFileEnumerator : IEnumerator<Shape>
+    {
+        private OleDbCommand _dbCommand;
+        private OleDbDataReader _dbReader;
+        private int _currentIndex = -1;
+        private bool _rawMetadataOnly;
+        private FileStream _mainStream;
+        private FileStream _indexStream;
+        private int _count;
+
+        public ShapeFileEnumerator(OleDbConnection dbConnection, string selectString, bool rawMetadataOnly, FileStream mainStream,
+                                   FileStream indexStream, int count)
+        {
+
+            _rawMetadataOnly = rawMetadataOnly;
+            _mainStream = mainStream;
+            _indexStream = indexStream;
+            _count = count;
+            _dbCommand = new OleDbCommand(selectString, dbConnection);
+            _dbReader = _dbCommand.ExecuteReader();
+        }
+
+
+        #region IEnumerator<Shape> Members
+
+        /// <summary>
+        /// Gets the current shape in the collection
+        /// </summary>
+        public Shape Current
+        {
+            get
+            {
+                // get the metadata
+                StringDictionary metadata = null;
+                if (!_rawMetadataOnly)
+                {
+                    metadata = new StringDictionary();
+                    for (int i = 0; i < _dbReader.FieldCount; i++)
+                    {
+                        metadata.Add(_dbReader.GetName(i),
+                            _dbReader.GetValue(i).ToString());
+                    }
+                }
+
+                // get the index record
+                byte[] indexHeaderBytes = new byte[8];
+                _indexStream.Seek(Header.HeaderLength + _currentIndex * 8, SeekOrigin.Begin);
+                _indexStream.Read(indexHeaderBytes, 0, indexHeaderBytes.Length);
+                int contentOffsetInWords = EndianBitConverter.ToInt32(indexHeaderBytes, 0, ProvidedOrder.Big);
+                int contentLengthInWords = EndianBitConverter.ToInt32(indexHeaderBytes, 4, ProvidedOrder.Big);
+
+                // get the data chunk from the main file - need to factor in 8 byte record header
+                int bytesToRead = (contentLengthInWords * 2) + 8;
+                byte[] shapeData = new byte[bytesToRead];
+                _mainStream.Seek(contentOffsetInWords * 2, SeekOrigin.Begin);
+                _mainStream.Read(shapeData, 0, bytesToRead);
+
+                return ShapeFactory.ParseShape(shapeData, metadata, _dbReader);
+            }
+        }
+
+        #endregion
+
+        #region IEnumerator Members
+
+        /// <summary>
+        /// Gets the current item in the collection
+        /// </summary>
+        object System.Collections.IEnumerator.Current
+        {
+            get
+            {
+                return this.Current;
+            }
+        }
+
+        public void Dispose()
+        {
+            _dbReader.Close();
+            _dbCommand.Dispose();
+        }
+
+        /// <summary>
+        /// Move to the next item in the collection (returns false if at the end)
+        /// </summary>
+        /// <returns>false if there are no more items in the collection</returns>
+        public bool MoveNext()
+        {
+
+            if (_currentIndex++ < (_count - 1))
+            {
+                // try to read the next database record
+                if (!_dbReader.Read())
+                {
+                    throw new InvalidOperationException("Metadata database does not contain a record for the next shape");
+                }
+
+                return true;
+            }
+            else
+            {
+                // reached the last shape
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Reset the enumerator
+        /// </summary>
+        public void Reset()
+        {
+            _dbReader.Close();
+            _dbReader = _dbCommand.ExecuteReader();
+            _currentIndex = -1;
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Hi All,

In `Program.cs` from ShapefileDemo I found that after executing Foreach statement `shapefile`  it will dispose `shapefile` object.

https://github.com/abfo/shapefile/blob/1a7be7d16f6d1e3308bd8a0fa4e015904f4ddf10/ShapefileDemo/Program.cs#L44

This behavior causes a problem when we need to get some `shapefile` properties after Foreach.  You can't access them because `shapefile` is disposed.

I abstracted out Enumerator to be able to dispose of Enumerator rather than whole `Shapefile`. Before we could only once iterate through collection once because Foreach statement disposing Enumerator on the end of execution. 

My intention of this fix is to follow `iterator patter` .

Thanks

Libor